### PR TITLE
Issueing control sequence to clear terminal buffer

### DIFF
--- a/powerletrics/powerletrics.py
+++ b/powerletrics/powerletrics.py
@@ -550,6 +550,7 @@ def get_data(stop_event):
                 })
             else:
                 if args.format == 'text':
+                    print("\033c", end="")
                     print_text(args, data_list, current_time, elapsed_time_ms, rapl_energy_sums)
                 else:
                     print_xml(args, data_list, current_time, elapsed_time_ms, rapl_energy_sums)


### PR DESCRIPTION
Since the output is constantly written to the terminal and does not always fill a full window height or is even longer than one window height it can become quite hard to follow the output stream when one for instance always wants to watch the top processes.

`top` solves this by using ncurses. Althoug this would als be nice here I think it is overkill.

This PR introduces the output of a control sequence that aligns the output with the top of the terminal. It does not clear the terminal buffer. (This could be done with `os.system('cls' if os.name == 'nt' else 'clear')`)